### PR TITLE
fix: add ECK component (real changelog uses it)

### DIFF
--- a/.github/ISSUE_TEMPLATE/changelog-entry.yml
+++ b/.github/ISSUE_TEMPLATE/changelog-entry.yml
@@ -13,7 +13,7 @@ body:
         **Format:** `<type> (<component>) <text>` — same as `changelog.md` today
 
         - **types:** `new`, `fix`, `security`, `warning`, `enhancement`
-        - **components:** `es`, `kbn`, `es|kbn`
+        - **components:** `es`, `kbn`, `eck` — combinable: `es|kbn`, `kbn|eck`, `es|kbn|eck`
         - text supports markdown links
 
   - type: input
@@ -31,7 +31,8 @@ body:
       placeholder: |
         new (es) 9.0.2, 8.18.2, 8.17.7 support
         new (kbn) 9.0.2, 8.18.2, 8.17.7 support
-        fix (es) [patching on Windows](https://forum.readonlyrest.com/t/...)
+        fix (eck) Operator handling of TLS rotation
+        fix (es|kbn) tenancy selector with jwt_auth
         security (es) CVE-2024-53382
       render: text
     validations:

--- a/.github/schemas/changelog-entry.schema.json
+++ b/.github/schemas/changelog-entry.schema.json
@@ -29,7 +29,7 @@
             "type": "array",
             "minItems": 1,
             "uniqueItems": true,
-            "items": { "enum": ["es", "kbn"] }
+            "items": { "enum": ["es", "kbn", "eck"] }
           },
           "text": {
             "type": "string",

--- a/.github/workflows/changelog_form.yml
+++ b/.github/workflows/changelog_form.yml
@@ -73,9 +73,15 @@ jobs:
               warning: 'warning', warn: 'warning',
               enhancement: 'enhancement', enh: 'enhancement', improve: 'enhancement',
             }
-            const COMP_MAP = {
-              es: ['es'], kbn: ['kbn'], 'es|kbn': ['es', 'kbn'],
-              'kbn|es': ['es', 'kbn'], both: ['es', 'kbn'],
+            // Components: es, kbn, eck — combinable with `|` (es|kbn, kbn|eck, es|kbn|eck, ...)
+            // Canonical output order: es, kbn, eck (matches existing changelog.md convention)
+            const COMP_ORDER = ['es', 'kbn', 'eck']
+            const parseComps = (raw) => {
+              const parts = raw.toLowerCase().replace(/\s+/g, '').split('|').filter(Boolean)
+              if (!parts.length) return null
+              const unknown = parts.filter(p => !COMP_ORDER.includes(p))
+              if (unknown.length) return null
+              return COMP_ORDER.filter(c => parts.includes(c))
             }
 
             const entries = []
@@ -90,9 +96,9 @@ jobs:
                 return
               }
               const type = TYPE_MAP[m.groups.type.toLowerCase()]
-              const comp = COMP_MAP[m.groups.comp.toLowerCase().replace(/\s+/g, '')]
+              const comp = parseComps(m.groups.comp)
               if (!type) errors.push(`Line ${i + 1}: unknown type \`${m.groups.type}\` — use one of: new, fix, security, warning, enhancement`)
-              if (!comp) errors.push(`Line ${i + 1}: unknown component \`${m.groups.comp}\` — use one of: es, kbn, es|kbn`)
+              if (!comp) errors.push(`Line ${i + 1}: unknown component \`${m.groups.comp}\` — use one of: es, kbn, eck (combinable with \`|\`, e.g. es|kbn)`)
               if (type && comp) entries.push({ type, components: comp, text: m.groups.text })
             })
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -102,7 +102,7 @@ Replacing fragile `changelog.md` flow at `beshu-tech/readonlyrest-docs` with str
   - Port parser from `src/integrations/repos/changelog/parse_changelog.py` (lines 37-58: `is_version_line`, `parse_version_details`)
   - For each version: extract bullets, parse `* **{emoji}{Type}** ({Component}) {text}`
   - Map emoji+label → schema enum (`🚀New` → `new`, `🐞Fix` → `fix`, `🚨Security Fix` → `security`, `⚠️Warning` → `warning`, `🧐Enhancement` → `enhancement`)
-  - Components: `ES` → `[es]`, `KBN` → `[kbn]`, `ES|KBN` → `[es, kbn]`
+  - Components: `ES` → `[es]`, `KBN` → `[kbn]`, `ECK` → `[eck]`, combinable via `|` (e.g. `ES|KBN` → `[es, kbn]`, `KBN|ECK` → `[kbn, eck]`)
   - Edge cases (~1.5%: `KBN < 7.9.0`, `KBN|PRO`): emit YAML with raw component string + flag for manual fix
   - Date: parse from `### (YYYY-MM-DD) What's new in **ROR X.Y.Z**` heading
   - Output: `readonlyrest-docs/changelog/{version}.yaml`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On parse error → bot posts an updateable comment on the issue. Fix the form bo
 `<type> (<component>) <text>` — matches existing `changelog.md` style. Optional colon also accepted.
 
 - **type**: `new`, `fix`, `security`, `warning`, `enhancement` (aliases: `feat`, `bugfix`, `sec`, `enh`)
-- **component**: `es`, `kbn`, `es|kbn`
+- **component**: `es`, `kbn`, `eck` — combinable with `|` (e.g. `es|kbn`, `kbn|eck`, `es|kbn|eck`)
 - **text**: any markdown — links, code, etc.
 
 Lines starting with `#` or `//` are ignored.


### PR DESCRIPTION
## What broke

Real-world test → form rejected with:
> Line 4: unknown component \`ECK\` — use one of: es, kbn, es|kbn

ECK = Elastic Cloud on Kubernetes. It's a first-class component in the actual ROR changelog, alongside ES and KBN. I dropped it from the enum.

## Fix

- Schema enum: `es`, `kbn`, `eck`
- Parser: replaced static COMP_MAP with dynamic `parseComps(raw)` — splits on \`|\`, validates each, returns canonical sorted output (`es, kbn, eck` order)
- Error message lists all 3 components + combinable hint
- Form placeholder + README + PLAN.md updated

Now valid: `es`, `kbn`, `eck`, `es|kbn`, `es|eck`, `kbn|eck`, `es|kbn|eck` (any subset, any input order → canonical output).

## Test

Once merged, re-file the issue with `(ECK)` entries → expect green parse.

> <signature>🦀 **sent by Claude Code**</signature>