### PR TITLE
feat: auto_merge toggle as config-as-code

### DIFF
--- a/.github/changelog-config.yml
+++ b/.github/changelog-config.yml
@@ -1,0 +1,12 @@
+# Changelog form behavior.
+# Single source of truth — change via PR, never via repo UI.
+# Consumed by .github/workflows/changelog_form.yml.
+
+# When true: form-opened PRs are auto-merged once required status checks pass
+# (or immediately if no branch protection). When false: maintainer reviews + clicks merge.
+#
+# In prod, recommended rollout:
+#   1. Ship with auto_merge: false — team learns the loop by reviewing each PR manually
+#   2. Once trusted, flip to true via PR + add branch protection requiring `validate-and-render`
+#   3. For the gate to actually block on CI: bot needs a PAT (GITHUB_TOKEN-authored PRs skip CI)
+auto_merge: false

--- a/.github/workflows/changelog_form.yml
+++ b/.github/workflows/changelog_form.yml
@@ -187,19 +187,48 @@ jobs:
           add-paths: |
             changelog/*.yaml
 
+      # Read changelog-form config (committed to repo at .github/changelog-config.yml).
+      # Adjusting auto_merge etc. = open a PR against the config file, not a UI flip.
+      - name: Read config
+        id: cfg
+        run: |
+          if [ -f .github/changelog-config.yml ]; then
+            echo "auto_merge=$(yq -r '.auto_merge // false' .github/changelog-config.yml)" >> "$GITHUB_OUTPUT"
+          else
+            echo "auto_merge=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Auto-merge toggle. Enable by setting `auto_merge: true` in .github/changelog-config.yml.
+      # With `--auto`, GitHub waits for required status checks (branch protection) before merging;
+      # if no checks required, merges immediately.
+      # CAVEAT: bot-authored PRs from GITHUB_TOKEN don't trigger CI (recursion guard).
+      # For a true "wait for green CI" gate in prod: use a PAT in the create-pr step above,
+      # AND set branch protection with validate-and-render required.
+      - name: Enable auto-merge
+        if: steps.parse.outputs.ok == 'true' && steps.cpr.outputs.pull-request-url && steps.cfg.outputs.auto_merge == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+
       - name: Comment PR link on issue and close
         if: steps.parse.outputs.ok == 'true' && steps.cpr.outputs.pull-request-url
         uses: actions/github-script@v7
         env:
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
           PR_OP: ${{ steps.cpr.outputs.pull-request-operation }}
+          AUTOMERGE: ${{ steps.cfg.outputs.auto_merge }}
         with:
           script: |
             const marker = '<!-- changelog-form-bot -->'
             const op = process.env.PR_OP
             const url = process.env.PR_URL
+            const automerge = process.env.AUTOMERGE === 'true'
             const verb = op === 'created' ? 'Opened' : 'Updated'
-            const body = `${marker}\n${verb} ${url}\n\n_Edit the YAML directly in the PR for fixes. Merge will trigger \`changelog.md\` regen._`
+            const automergeNote = automerge
+              ? '\n\n_Auto-merge enabled (`.github/changelog-config.yml`) — will merge once required checks pass._'
+              : '\n\n_Edit the YAML directly in the PR for fixes. Merge will trigger `changelog.md` regen._'
+            const body = `${marker}\n${verb} ${url}${automergeNote}`
             const ref = {
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/PLAN.md
+++ b/PLAN.md
@@ -67,6 +67,16 @@ gh label create changelog-entry --repo {owner}/{repo} \
 
 `.github/ISSUE_TEMPLATE/config.yml` should have `blank_issues_enabled: false`. GitHub's native "Maintainers only" badge appears on Blank issue under this setting; can't be applied to custom forms.
 
+### 4. (Optional, recommended for prod once trusted) Auto-merge
+
+Configured in `.github/changelog-config.yml` — `auto_merge: true` makes form-opened PRs auto-merge once required checks pass.
+
+Requires:
+- "Allow auto-merge" on at repo: `gh api -X PATCH repos/{owner}/{repo} -F allow_auto_merge=true`
+- For the gate to actually block on CI (not just merge instantly): PAT in `changelog_form.yml` replacing `secrets.GITHUB_TOKEN` + branch protection requiring `validate-and-render`. Without that, bot-authored PRs skip CI (GH recursion guard) and the toggle effectively becomes "merge immediately."
+
+Prod rollout: ship with `auto_merge: false`, team manually reviews PRs first releases, then PR-flip the config to `true` once trusted.
+
 ---
 
 ## Phase 1 — Demo polish (`ton77v/changelog-forms-demo`)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ Three primitives: a form, a YAML file, a render. No DB, no admin UI, no extra to
 - **Pre-release sorting**: `1.69.0-rc1` orders correctly vs `1.69.0` (uses `semver.rcompare`)
 - **Validation on PR**: `pull_request` trigger runs schema + filename check before merge
 
+## Config
+
+[`.github/changelog-config.yml`](.github/changelog-config.yml) — single source for form behavior. Changes go through PR review like any other code.
+
+| Key | Default | Effect |
+|---|---|---|
+| `auto_merge` | `false` | Maintainer reviews + clicks merge |
+| `auto_merge: true` | — | Form-opened PR is auto-merged once required checks pass (or immediately if none required) |
+
+**Prerequisite for `auto_merge: true`**: "Allow auto-merge" must be enabled in Settings → General. Set via API:
+
+```bash
+gh api -X PATCH repos/{owner}/{repo} -F allow_auto_merge=true
+```
+
+**To make auto-merge wait on real CI** (vs merging instantly when no checks required): use a PAT in `changelog_form.yml` (replace `secrets.GITHUB_TOKEN` in the `create-pull-request` step) **and** add branch protection requiring the `validate-and-render` check. Without that, bot-authored PRs skip CI (GH recursion guard).
+
 ## Stack
 
 Two npm deps installed per-run: `ajv-cli` (schema), `semver` (sort). One official action: `actions/github-script@v7`. One community action: `peter-evans/create-pull-request@v6` (idempotent branch + PR). Pure JS inline elsewhere.
@@ -83,6 +100,7 @@ Two npm deps installed per-run: `ajv-cli` (schema), `semver` (sort). One officia
 - `.github/workflows/changelog_form.yml` — parse form + write YAML + open PR
 - `.github/workflows/render_changelog.yml` — validate + regen `changelog.md`
 - `.github/schemas/changelog-entry.schema.json` — single source of YAML truth
+- `.github/changelog-config.yml` — form behavior settings (auto-merge etc.)
 - `changelog/1.41.0.yaml` — example YAML (single source of truth per release)
 - `changelog.md` — auto-generated; editing this file is wrong, edit the YAML
 - [`PLAN.md`](PLAN.md) — full migration plan across 3 repos


### PR DESCRIPTION
## Why

You asked for auto-merge as a repo-level setting, not per-entry. Initial approach was a GitHub Actions Variable (UI-flipped). You pushed back — config-as-code is better: visible in repo, version-controlled, PR-reviewable.

## What lands

- **NEW** `.github/changelog-config.yml` — single source for form behavior. Starts with one key: \`auto_merge: false\`. Future toggles land here.
- Workflow reads it with \`yq\` and gates the auto-merge step on it.
- Issue comment + README + PLAN.md updated to point at the config file.

## Behavior

| Config | Effect |
|---|---|
| \`auto_merge: false\` (default) | Status quo — maintainer reviews + clicks merge |
| \`auto_merge: true\` | Form-opened PR is auto-merged when required status checks pass (immediately if none required) |

## Prerequisites for \`auto_merge: true\`

Documented in PLAN.md (Repo setup prerequisites § 4):
- \`gh api -X PATCH repos/{owner}/{repo} -F allow_auto_merge=true\`
- To actually wait on CI (vs merge instantly): swap \`secrets.GITHUB_TOKEN\` → PAT in \`changelog_form.yml\` + add branch protection requiring \`validate-and-render\`. Without that, bot-authored PRs skip CI (GH recursion guard).

## Prod rollout suggestion

1. Ship with \`auto_merge: false\` — team learns the loop by manually reviewing each PR
2. Once trusted, open a PR flipping it to \`true\` + add the branch protection + PAT
3. From then on, form → MD on master ~2 min, hands-off, audited

## Try it after merge

To test in this demo: PR-flip \`auto_merge: false\` → \`true\` and file an issue. Bot's PR should auto-merge instantly (no branch protection in demo).

> <signature>🦀 **sent by Claude Code**</signature>