### PR TITLE
config: enable auto_merge for demo

### DIFF
--- a/.github/changelog-config.yml
+++ b/.github/changelog-config.yml
@@ -9,4 +9,4 @@
 #   1. Ship with auto_merge: false — team learns the loop by reviewing each PR manually
 #   2. Once trusted, flip to true via PR + add branch protection requiring `validate-and-render`
 #   3. For the gate to actually block on CI: bot needs a PAT (GITHUB_TOKEN-authored PRs skip CI)
-auto_merge: false
+auto_merge: true


### PR DESCRIPTION
## Flip

\`auto_merge: false\` → \`true\`.

## Effect

Next form-opened PR will be auto-merged immediately (demo has no branch protection → \`--auto\` triggers right away). \`changelog.md\` regenerates via render workflow on the push to main.

## Caveat (already documented)

No CI gate in front of the auto-merge here. Bot-authored PRs from \`GITHUB_TOKEN\` skip downstream workflows. For a real gate in prod: PAT + branch protection requiring \`validate-and-render\`.

This is the demo flavor of "what auto-merge looks like." Prod will need the PAT step.

> <signature>🦀 **sent by Claude Code**</signature>