### PR TITLE
feat: components_raw support (Phase 2 sanity)

### DIFF
--- a/.github/schemas/changelog-entry.schema.json
+++ b/.github/schemas/changelog-entry.schema.json
@@ -31,6 +31,11 @@
             "uniqueItems": true,
             "items": { "enum": ["es", "kbn", "eck"] }
           },
+          "components_raw": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional. Preserves original separator/order (e.g. 'KBN/ES', 'ES & KBN') for hash parity with ror-api's stored LLM descriptions. Only present on migrated historical entries; new form-driven entries omit it."
+          },
           "text": {
             "type": "string",
             "minLength": 1

--- a/.github/workflows/render_changelog.yml
+++ b/.github/workflows/render_changelog.yml
@@ -84,7 +84,10 @@ jobs:
               warning: '⚠️Warning',
               enhancement: '🧐Enhancement',
             }
-            const compStr = (cs) => cs.map(c => c.toUpperCase()).join('|')
+            // `components_raw` (optional) preserves original separator/order for migrated entries
+            // — required for hash parity with ror-api's stored LLM descriptions. New form-driven
+            // entries omit it; renderer falls back to canonical `ES|KBN` join.
+            const compStr = (e) => e.components_raw || e.components.map(c => c.toUpperCase()).join('|')
 
             let md = '# Changelog\n\n'
             md += '<!-- AUTO-GENERATED from changelog/*.yaml — do not edit directly -->\n\n'
@@ -92,7 +95,7 @@ jobs:
               md += `### (${r.release_date}) What's new in **ROR ${r.version}**\n`
               for (const e of r.entries) {
                 const label = TYPE_EMOJI[e.type] || e.type
-                md += `* **${label}** (${compStr(e.components)}) ${e.text}\n`
+                md += `* **${label}** (${compStr(e)}) ${e.text}\n`
               }
               md += '\n'
             }

--- a/changelog/1.69.0.yaml
+++ b/changelog/1.69.0.yaml
@@ -1,0 +1,78 @@
+version: "1.69.0"
+release_date: "2026-04-02"
+entries:
+  - type: security
+    components: [kbn]
+    text: "[CVE-2026-24001](https://nvd.nist.gov/vuln/detail/CVE-2026-24001), [CVE-2025-69873](https://nvd.nist.gov/vuln/detail/CVE-2025-69873), [CVE-2026-2391](https://nvd.nist.gov/vuln/detail/CVE-2026-2391), [CVE-2026-25639](https://nvd.nist.gov/vuln/detail/CVE-2026-25639), [CVE-2026-27904](https://nvd.nist.gov/vuln/detail/CVE-2026-27904), [CVE-2026-3449](https://nvd.nist.gov/vuln/detail/CVE-2026-3449), [CVE-2025-15599](https://nvd.nist.gov/vuln/detail/CVE-2025-15599), [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750), [CVE-2026-4867](https://nvd.nist.gov/vuln/detail/CVE-2026-4867), [CVE-2026-34601](https://www.tenable.com/cve/CVE-2026-34601), [CVE-2022-31129](https://nvd.nist.gov/vuln/detail/cve-2022-31129)"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "[Added Fleet support via native API key and service account token authentication (ES 7.14+)](https://docs.readonlyrest.com/elasticsearch/fleet)"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "The ReadonlyREST Audit Dashboard available in the Kibana plugin now supports audit events written to data streams"
+  - type: new
+    components: [es, kbn]
+    components_raw: "KBN/ES"
+    text: "The ReadonlyREST Audit Dashboard provided by the Kibana plugin can now be used with the ECS (Elastic Common Schema) audit index"
+  - type: new
+    components: [kbn]
+    text: "[Added support for opening different tenancies in separate tabs](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)"
+  - type: new
+    components: [kbn]
+    text: "[Added support for sharing links to Kibana visualizations for the selected tenancy](https://forum.readonlyrest.com/t/multi-tenancy-and-link-sharing/1978/3)"
+  - type: new
+    components: [kbn]
+    text: "Added support for rolling upgrades when upgrading the ROR Elasticsearch plugin and ROR Kibana plugin in a cluster"
+  - type: enhancement
+    components: [kbn]
+    text: "Removed the need for manual username input in the impersonation mechanism"
+  - type: enhancement
+    components: [kbn]
+    text: "Fixed an error in Kibana caused by empty data streams in Kibana 8.18.0+"
+  - type: enhancement
+    components: [kbn]
+    text: "Added a fallback for an empty `indices` field in the Audit Dashboard"
+  - type: enhancement
+    components: [kbn]
+    text: "[Updated custom metadata examples to use the new method. `getIdentitySession` and `getAuthorizationHeaders` are now deprecated in favor of `getUserRequestIdentity`, `getIdentitySessionHeaders`, and `getWhitelistedHeaders`](https://docs.readonlyrest.com/develop/examples/custom-middleware)"
+  - type: enhancement
+    components: [es]
+    text: "[`token_authentication` rule extended with `api_key` and `service_token` types](https://docs.readonlyrest.com/elasticsearch#token_authentication)"
+  - type: enhancement
+    components: [es]
+    text: "[Audit log entries and ACL history now include a human-readable reason when a request is denied, making access-control troubleshooting significantly easier](https://forum.readonlyrest.com/t/distinguish-between-wrong-credentials-and-missing-permissions/2914)"
+  - type: enhancement
+    components: [es]
+    text: "Added the new `matched_block_names` field to audit entries created by audit log serializers other than ECS and custom serializers. The `reason` field is now deprecated."
+  - type: enhancement
+    components: [es]
+    text: "Users defined with LDAP, external, and `ror_kbn` authentication are no longer treated as local users by the impersonation mechanism"
+  - type: enhancement
+    components: [es]
+    text: "The ROR Kibana plugin can no longer be used when the `prompt_for_basic_auth: true` setting is configured"
+  - type: fix
+    components: [kbn]
+    text: "Resolved a memory leak related to direct calls via the Kibana API"
+  - type: fix
+    components: [kbn]
+    text: "No longer shows the \"Data Set Quality\" and \"Index management\" applications to users with RO or RO_strict access"
+  - type: fix
+    components: [kbn]
+    text: "Fixed JWT token authorization when using embedded Kibana"
+  - type: fix
+    components: [kbn]
+    text: "Fixed the styling of the page-not-found screen for Kibana 9.x"
+  - type: fix
+    components: [kbn]
+    text: "Correctly displays the \"Who uses what indices?\" Audit Dashboard visualization when indices are not specified in the audit events"
+  - type: fix
+    components: [es]
+    text: "[Improved stability when sending audit logs to another cluster, so temporary remote cluster outages no longer affect the main cluster](https://forum.readonlyrest.com/t/sending-logs-to-another-cluster/2925)"
+  - type: fix
+    components: [es]
+    text: "Fixed Search Profiler being inactive in Kibana 8.18.0+"
+  - type: fix
+    components: [es]
+    text: "`beshultd/elasticsearch-readonlyrest` images for ES 7.16.x, 7.17.0–7.17.6, and 8.0.x–8.4.x now ship with a patched JDK, replacing bundled JDK 17.0.0–17.0.4 / JDK 18, which crashes on cgroup v2 hosts due to JDK-8287073"


### PR DESCRIPTION
## Why

Built the Phase 2 migration script. Ran it locally against the real `beshu-tech/readonlyrest-docs/changelog.md`. Results:

| Metric | Value |
|---|---|
| Versions | 66 |
| Entries | 518 |
| Hash parity (initial) | 59/66 |
| Hash parity (with components_raw) | **66/66** ✓ |
| Edge cases needing manual fix | 3 (PRO + 2× version-qualified KBN) |

## Hash mismatch root cause (load-bearing finding)

7 versions had hash mismatches purely because original used non-canonical separators or order:
- `(KBN/ES)` × 5 entries
- `(KBN|ES)` × 2 entries  
- `(ES & KBN)` × 1 entry

My initial render produced canonical `(ES|KBN)` for all → hash differs → ror-api would re-run LLM for all 7 stored entries (cost + time).

## Fix

New optional schema field `components_raw` — preserves original verbatim. Render uses it when present; falls back to canonical for new form-driven entries (which always omit it).

| Yaml | Renders as |
|---|---|
| `components: [es, kbn]` | `(ES\|KBN)` (canonical, default for new entries) |
| `components: [es, kbn], components_raw: "KBN/ES"` | `(KBN/ES)` (migration entries) |
| `components: [es, kbn], components_raw: "ES & KBN"` | `(ES & KBN)` |

## Files

- `.github/schemas/changelog-entry.schema.json` — adds optional `components_raw`
- `.github/workflows/render_changelog.yml` — `compStr` reads raw first
- `changelog/1.69.0.yaml` — fixture from migration output, tests the round-trip end-to-end

## Verification after merge

1. Render workflow fires on push to main
2. Generated `changelog.md` should contain `(KBN/ES)` for the three 1.69.0 entries
3. Existing entries (no `components_raw`) still render canonically

## Phase 2 outputs

Migration script outputs (not in this PR, local only) at `tmp/yaml-migration/`:
- `changelog/*.yaml` × 66
- `parity_report.json` (now 100% match)
- `edge_cases.json` (3 entries)

Next: push to `beshu-tech/readonlyrest-docs` feature branch `migrate/yaml-changelog` for Mateusz review — pending your go-ahead.

> <signature>🦀 **sent by Claude Code**</signature>